### PR TITLE
fix: fix string trimming at fixed location variable 

### DIFF
--- a/scripts/kanagawa.sh
+++ b/scripts/kanagawa.sh
@@ -247,7 +247,7 @@ main() {
 
     elif [ $plugin = "weather" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@kanagawa-weather-colors" "orange dark_gray")
-      script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location $fixed_location)"
+      script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location '$fixed_location')"
 
     elif [ $plugin = "time" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@kanagawa-time-colors" "dark_purple white")

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -23,7 +23,7 @@ fetch_weather_information()
 {
   display_weather=$1
   # it gets the weather condition textual name (%C), and the temperature (%t)
-  curl -sL wttr.in/$fixedlocation\?format="%C+%t$display_weather"
+  curl -sL wttr.in/${fixedlocation// /%20}\?format="%C+%t$display_weather"
 }
 
 #get weather display

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -20,7 +20,7 @@ main()
 
   if [ "$(expr ${TIME_LAST} + ${RUN_EACH})" -lt "${TIME_NOW}" ]; then
     # Run weather script here
-    $current_dir/weather.sh $fahrenheit $location $fixedlocation > "${DATAFILE}"
+    $current_dir/weather.sh $fahrenheit $location "$fixedlocation" > "${DATAFILE}"
     echo "${TIME_NOW}" > "${LAST_EXEC_FILE}"
   fi
 


### PR DESCRIPTION
**Bug**: If the user set a string with spaces for fixed location, the string is trimmed and only the first word is set into the variable, making impossible to get the correct weather for that location. 

Example: 

_.tmux.config_
`set -g @kanagawa-fixed-location "São Paulo"`

_weather.sh / weather_wrapper.sh_
$fixerlocation value = "São"

**Solution**: Allowing setting string with spaces on those variables. 