### PR TITLE
remove manual permission part from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,6 @@ It is possible that not all color values are listed here. For the complete list,
 - Countdown to tmux-continuum save
 - Current working directory of tmux pane
 
-## Known issues
-
-You may need to manually give permission to plugin's scripts.
-
-```bash
-cd ~/.tmux/plugins/tmux-kanagawa
-chmod u+x kanagawa.tmux
-chmod u+x ./**/*.sh
-```
-
 ## Todo
 
 - [ ] meaningful / semantic color names


### PR DESCRIPTION
[Commit 777ca48](https://github.com/Nybkox/tmux-kanagawa/commit/777ca48e76f77f9e1d821986b43c871a1bd9b2d0) changes the permissions of kanagawa.tmux to executable so this part of the README is no longer necessary. Before this commit it only had regular file permissions, that's why this issue was present.