### PR TITLE
Update colors.sh

### DIFF
--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,8 +1,8 @@
   # Kanagawa Color Pallette
 
   fuji_white='#dcd7ba'
-  sumi_ink_4='#2a2a37'
-  sumi_ink_2='#1a1a22'
+  sumi_ink_4='#181820'
+  sumi_ink_2='#1f1f28'
   sumi_ink_5='#363646'
   sumi_ink_6='#54546D'
   wave_aqua='#6a9589'


### PR DESCRIPTION
altered sumi_ink4 & 2 to ensure proper cohesion when running alacritty and nvim with the same theme. 

sumi_ink_4='#181820'
sumi_ink_2='#1f1f28'

tmux bar now matches the kanagawa-wave theme nvim bar, and the background color matches the kanagawa-wave theme in both alacritty and nvim.

Result:

![image](https://github.com/user-attachments/assets/33e2fd52-c2c7-43d9-b9ce-bdb75b465196)
