### PR TITLE
Update gpu_usage.sh to better support the active GPU

### DIFF
--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -9,7 +9,7 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+      gpu=$(glxinfo | grep -e OpenGL.renderer | awk '{print $4}')
       echo $gpu
       ;;
 

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -38,7 +38,8 @@ main()
 {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@kanagawa-refresh-rate" 5)
-  gpu_label=$(get_tmux_option "@kanagawa-gpu-usage-label" "GPU")
+  name=$(glxinfo | grep "OpenGL renderer" | cut -d':' -f2 | sed -E 's/.*?(RTX|GTX|RX|R9|R7|R5|HD|Arc|UHD|Iris|HD Graphics) ([0-9]+[A-Za-z0-9]*).*/\1 \2/' | xargs)
+  gpu_label=$(get_tmux_option "@kanagawa-gpu-usage-label" "GPU ($name)")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"
   sleep $RATE

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -38,7 +38,7 @@ main()
 {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@kanagawa-refresh-rate" 5)
-  name=$(glxinfo | grep "OpenGL renderer" | cut -d':' -f2 | sed -E 's/.*?(RTX|GTX|RX|R9|R7|R5|HD|Arc|UHD|Iris|HD Graphics) ([0-9]+[A-Za-z0-9]*).*/\1 \2/' | xargs)
+  name=$(glxinfo | grep -e OpenGL.renderer | cut -d':' -f2 | sed -E 's/.*?(RTX|GTX|RX|R9|R7|R5|HD|Arc|UHD|Iris|HD Graphics) ([0-9]+[A-Za-z0-9]*).*/\1 \2/' | xargs)
   gpu_label=$(get_tmux_option "@kanagawa-gpu-usage-label" "GPU ($name)")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"


### PR DESCRIPTION
CC: @Nybkox

Switch the GPU detection to use `glxinfo` to detect the active GPU. Specifically for those, like myself, who use a laptop that (technically) has multiple GPUs.

![Screenshot From 2024-11-02 17-41-43](https://github.com/user-attachments/assets/36484843-a989-4cc4-a88f-ad0d59c43656)
