### PR TITLE
Add better label support for GPU usage

### DIFF
--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -38,9 +38,16 @@ main()
 {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@kanagawa-refresh-rate" 5)
-  name=$(glxinfo | grep -e OpenGL.renderer | cut -d':' -f2 | sed -E 's/.*?(RTX|GTX|RX|R9|R7|R5|HD|Arc|UHD|Iris|HD Graphics) ([0-9]+[A-Za-z0-9]*).*/\1 \2/' | xargs)
-  gpu_label=$(get_tmux_option "@kanagawa-gpu-usage-label" "GPU ($name)")
+  name="GPU"
+
+  if installed "glxinfo"; then
+    type=$(glxinfo | grep -e OpenGL.renderer | cut -d':' -f2 | sed -E 's/.*?(RTX|GTX|RX|R9|R7|R5|HD|Arc|UHD|Iris|HD Graphics) ([0-9]+[A-Za-z0-9]*).*/\1 \2/' | xargs)
+    name="GPU ($type)"
+  fi
+
+  gpu_label=$(get_tmux_option "@kanagawa-gpu-usage-label" "$name")
   gpu_usage=$(get_gpu)
+
   echo "$gpu_label $gpu_usage"
   sleep $RATE
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -40,3 +40,7 @@ normalize_percent_len() {
   let right_spaces=($diff_len)/2
   printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
 }
+
+installed() {
+  command -v $1 &> /dev/null
+}


### PR DESCRIPTION
Added better label support for GPU usage. On linux with `glxinfo` you get the `GPU (<TYPE>) <PERCENT>` info. If `glxinfo` does not exist it just goes back to `GPU` and if the `usage` is `"unknown"` then you get `GPU unknown`, like what used to exist before I pushed the `glxinfo` change show it shows up like others are used to.