### PR TITLE
fix bug: [You are not associated with an Airport network] on Mac OS 15.*

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -2,41 +2,52 @@
 # setting the locale, some users have issues with different locales, this forces the correct one
 export LC_ALL=en_US.UTF-8
 
-HOSTS="google.com github.com example.com"
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source $current_dir/utils.sh
 
-get_ssid()
-{
+HOSTS="google.com github.com example.com"
+network_interface=$(get_tmux_option "@kanagawa-network-bandwidth" "en0")
+wifi_label=$(get_tmux_option "@kanagawa-network-wifi-label" "")
+ethernet_label=$(get_tmux_option "@kanagawa-network-ethernet-label" "Ethernet")
+
+get_ssid() {
   # Check OS
   case $(uname -s) in
-    Linux)
-      SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
-      if [ -n "$SSID" ]; then
-        printf '%s' "$SSID"
-      else
-        echo 'Ethernet'
-      fi
-      ;;
+  Linux)
+    SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
+    if [ -n "$SSID" ]; then
+      printf '%s' "$SSID"
+    else
+      echo 'Ethernet'
+    fi
+    ;;
 
-    Darwin)
-      if networksetup -getairportnetwork en0 | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
-        echo "$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
-      else
-        echo 'Ethernet'
-      fi
-      ;;
+  Darwin)
+    local wifi_network
+    local airport
 
-    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-      # leaving empty - TODO - windows compatability
-      ;;
+    wifi_network=$(ipconfig getsummary $network_interface | awk -F ' SSID : ' '/ SSID : / {print $2}')
+    airport=$(networksetup -getairportnetwork $network_interface | cut -d ':' -f 2)
 
-    *)
-      ;;
+    if [[ $airport != "You are not associated with an AirPort network." ]]; then
+      echo "$wifi_label$airport" | sed 's/^[[:blank:]]*//g'
+    elif [[ $wifi_network != "" ]]; then
+      echo "$wifi_label$wifi_network" | sed 's/^[[:blank:]]*//g'
+    else
+      echo "$ethernet_label"
+    fi
+    ;;
+
+  CYGWIN* | MINGW32* | MSYS* | MINGW*)
+    # leaving empty - TODO - windows compatability
+    ;;
+
+  *) ;;
   esac
 
 }
 
-main()
-{
+main() {
   network="Offline"
   for host in $HOSTS; do
     if ping -q -c 1 -W 1 $host &>/dev/null; then


### PR DESCRIPTION
Patch to fix an error message shown in the network field on the right status line (See this [issue](https://github.com/dracula/tmux/issues/290)) when running on Mac OS 15.0 or later since Apple has changed its functionality.  

Also, the network interface name is now customizable (since some  may use `en1` rather than `en0` as the wifi interface on Mac) and can be specified in `~/.tmux.conf` through `set -g @kanagawa-network-bandwidth`.

