### PR TITLE
refactor(network_bandwidth): fix broken state on some systems & pad output

### DIFF
--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -83,7 +83,7 @@ bandwidth_to_unit() {
     size="$i"
   done
 
-  result="$(awk -v a="$1" -v b="$size" 'BEGIN { printf "%.2f\n", a / b }' </dev/null)"
+  result="$(awk -v a="$1" -v b="$size" 'BEGIN { printf "%.1f\n", a / b }' </dev/null)"
 
   echo "$result ${SIZE[$size]}"
 }

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -23,7 +23,7 @@ interface_get() {
     case "$(uname -s)" in
     Linux)
       if type ip >/dev/null; then
-        name="$(ip -o route get 192.168.0.0 | awk '{print $5}')"
+        name="$(ip -o route get 192.168.0.0 | grep -oP '(?<=dev )\S+')"
       fi
       ;;
     Darwin)

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -10,9 +10,9 @@ readonly DOWNLOAD=1
 # SIZE index are the multiple of the unit byte and value the internationally recommended unit symbol in sec
 readonly SIZE=(
   [1]='B/s'
-  [1024]='kB/s'
-  [1048576]='MB/s'
-  [1073741824]='GB/s'
+  [1024]='kiB/s'
+  [1048576]='MiB/s'
+  [1073741824]='GiB/s'
 )
 
 # interface_get try to automaticaly get the used interface if network_name is empty

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -84,8 +84,9 @@ bandwidth_to_unit() {
   done
 
   result="$(awk -v a="$1" -v b="$size" 'BEGIN { printf "%.1f\n", a / b }' </dev/null)"
-
-  echo "$result ${SIZE[$size]}"
+  result_with_unit="$result ${SIZE[$size]}"
+  padded_result=$(printf "%11s" "$result_with_unit")
+  echo "$padded_result"
 }
 
 main() {

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -83,10 +83,7 @@ bandwidth_to_unit() {
     size="$i"
   done
 
-  local result="0.00"
-  if (($1 != 0)); then
-    result="$(awk -v a="$1" -v b="$size" 'BEGIN { printf "%.2f\n", a / b }' </dev/null)"
-  fi
+  result="$(awk -v a="$1" -v b="$size" 'BEGIN { printf "%.2f\n", a / b }' </dev/null)"
 
   echo "$result ${SIZE[$size]}"
 }

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # setting the locale, some users have issues with different locales, this forces the correct one
-export LC_ALL=en_US.UTF-8
+export LC_ALL=C.UTF-8
 
 fahrenheit=$1
 location=$2


### PR DESCRIPTION
This PR introduces several amendments:
1. It fixes `network_bandwidth` on some linux distributions, where `ip` command has a bit different output.
    For example, on my machine it always shows 0.0 due to incorrectly recognized network iface.
    ![broken_net](https://github.com/user-attachments/assets/033a0fc3-80a2-4fd8-bfb7-94ba0f8872f1)
2. It pads output so that changing net speed does not make status bar to dance.
3. Use IEC units for speed instead of decimal ones.
4. Use only one decimal place for speed. More is not helpful and only pollutes status bar.
5. It fixes CPU stress out to 100% due to unavailable `en_US.UTF-8` locale on some system.

@Nybkox can you please take a look?

Before:

https://github.com/user-attachments/assets/7343b30b-e2d4-4645-bc49-fcbbd6914a63

After:

https://github.com/user-attachments/assets/b188d546-ac31-47ad-aecf-880ccfda4bde


`weather.sh` script stress out CPU due to commands like `echo Patchy rain nearby +8°C | rev` if `en_US.UTF-8` locale is unavailable:
![stress](https://github.com/user-attachments/assets/9476f9c4-441d-4e14-8954-415617228e41)
