### PR TITLE
update dark_gray to default to sumi_ink_3

### DIFF
--- a/scripts/theme.sh
+++ b/scripts/theme.sh
@@ -29,7 +29,7 @@ set_theme() {
     *)
       white=$fuji_white
       gray=$sumi_ink_4
-      dark_gray=$sumi_ink_2
+      dark_gray=$sumi_ink_3
       light_purple=$sumi_ink_5
       dark_purple=$sumi_ink_6
       cyan=$wave_aqua


### PR DESCRIPTION
This needs to happen to fix #29 . Also see the [default bg color at Kangawa's source code](https://github.com/rebelot/kanagawa.nvim/blob/4de88d695634a8776c687af8e7436cfa074aa0c0/lua/kanagawa/themes.lua#L103)