### PR TITLE
feat: Allow short hostnames for ssh_session

### DIFF
--- a/scripts/ssh_session.sh
+++ b/scripts/ssh_session.sh
@@ -4,6 +4,7 @@
 export LC_ALL=en_US.UTF-8
 
 show_ssh_session_port=$1
+show_ssh_session_short_hostname=$2
 
 parse_ssh_port() {
   # Get port from connection
@@ -111,6 +112,12 @@ ssh_connected() {
 
 main() {
   hostname=$(get_info hostname)
+
+  # Use short hostname if option enabled
+  if [ "$show_ssh_session_short_hostname" == "true" ]; then
+    hostname=$(echo $hostname | cut -d. -f1)
+  fi
+
   user=$(get_info whoami)
 
   # Only show port info if ssh session connected (no localhost) and option enabled

--- a/scripts/ukiyo.sh
+++ b/scripts/ukiyo.sh
@@ -77,6 +77,7 @@ main() {
   show_synchronize_panes_label=$(get_tmux_option "@ukiyo-synchronize-panes-label" "Sync")
   time_format=$(get_tmux_option "@ukiyo-time-format" "")
   show_ssh_session_port=$(get_tmux_option "@ukiyo-show-ssh-session-port" false)
+  show_ssh_session_short_hostname=$(get_tmux_option "@ukiyo-ssh-session-short-hostname" false)
   IFS=' ' read -r -a plugins <<<$(get_tmux_option "@ukiyo-plugins" "battery network weather")
   show_empty_plugins=$(get_tmux_option "@ukiyo-show-empty-plugins" true)
 
@@ -327,7 +328,7 @@ main() {
 
     elif [ $plugin = "ssh-session" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@ukiyo-ssh-session-colors" "accent bg_pane")
-      script="#($current_dir/ssh_session.sh $show_ssh_session_port)"
+      script="#($current_dir/ssh_session.sh $show_ssh_session_port $show_ssh_session_short_hostname)"
 
     elif [ $plugin = "openconnect" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@ukiyo-openconnect-colors" "info bg_pane")


### PR DESCRIPTION
This PR adds the ability to configure the theme to only display "short hostnames" (i.e. `hostname` instead of `hostname.local.lan`) when using the ssh_session script. 