### PR TITLE
feat: add bru theme with espresso and latte variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ set -g @ukiyo-theme "onedark/deep"     # Deepest background
 set -g @ukiyo-theme "onedark/warm"     # Warm tones
 set -g @ukiyo-theme "onedark/warmer"   # Warmer tones
 
+# Bru variants
+set -g @ukiyo-theme "bru/espresso"  # default dark
+set -g @ukiyo-theme "bru/latte"     # light
+
 # Legacy format still works
 set -g @ukiyo-theme "wave"  # same as kanagawa/wave
 ```

--- a/menu_items/colors.sh
+++ b/menu_items/colors.sh
@@ -69,6 +69,10 @@ render() {
   # Dracula variants
   local d_classic=$(mark_if_active "$current_theme" "dracula/classic" "Classic")
 
+  # Bru variants
+  local b_espresso=$(mark_if_active "$current_theme" "bru/espresso" "Espresso")
+  local b_latte=$(mark_if_active "$current_theme" "bru/latte" "Latte")
+
   tmux display-menu -T "#[align=centre fg=green]Themes" -x R -y P \
     "" \
     "" \
@@ -114,6 +118,10 @@ render() {
     "" \
     "#[align=centre]─── Dracula ───" "" "" \
     "$d_classic" d "run -b '#{@ukiyo-root}/scripts/actions.sh set_state_and_tmux_option theme dracula/classic'" \
+    "" \
+    "#[align=centre]─── Bru ───" "" "" \
+    "$b_espresso" e "run -b '#{@ukiyo-root}/scripts/actions.sh set_state_and_tmux_option theme bru/espresso'" \
+    "$b_latte" l "run -b '#{@ukiyo-root}/scripts/actions.sh set_state_and_tmux_option theme bru/latte'" \
     "" \
     "<-- Back" b "run -b 'source #{@ukiyo-root}/menu_items/main.sh'" \
     "Close menu" q ""

--- a/themes/bru/espresso.sh
+++ b/themes/bru/espresso.sh
@@ -1,0 +1,13 @@
+# Bru Espresso (dark)
+
+text=$bru_espresso_fg
+bg_bar=$bru_espresso_bg_soft
+bg_pane=$bru_espresso_bg
+highlight=$bru_espresso_bg_hi
+selection=$bru_espresso_border
+info=$bru_espresso_blue
+accent=$bru_espresso_green
+notice=$bru_espresso_orange
+error=$bru_espresso_red
+muted=$bru_espresso_fg_muted
+alert=$bru_espresso_yellow

--- a/themes/bru/latte.sh
+++ b/themes/bru/latte.sh
@@ -1,0 +1,13 @@
+# Bru Latte (light)
+
+text=$bru_latte_fg
+bg_bar=$bru_latte_bg_soft
+bg_pane=$bru_latte_bg
+highlight=$bru_latte_bg_hi
+selection=$bru_latte_border
+info=$bru_latte_blue
+accent=$bru_latte_green
+notice=$bru_latte_orange
+error=$bru_latte_red
+muted=$bru_latte_fg_muted
+alert=$bru_latte_yellow

--- a/themes/bru/palette.sh
+++ b/themes/bru/palette.sh
@@ -1,0 +1,60 @@
+# Bru Color Palette
+# https://github.com/kmf/bru
+
+# Espresso (dark) — neutrals
+bru_espresso_bg='#1c1814'
+bru_espresso_bg_soft='#26211c'
+bru_espresso_bg_hi='#322b23'
+bru_espresso_border='#3a332b'
+bru_espresso_fg='#f5e8c7'
+bru_espresso_fg_alt='#fbf3db'
+bru_espresso_fg_muted='#8a7f6f'
+
+# Espresso accents
+bru_espresso_yellow='#dbb32d'
+bru_espresso_orange='#ed8649'
+bru_espresso_red='#fa5750'
+bru_espresso_magenta='#f275be'
+bru_espresso_violet='#af88eb'
+bru_espresso_blue='#4695f7'
+bru_espresso_teal='#41c7b9'
+bru_espresso_green='#75b938'
+
+# Espresso bright accents
+bru_espresso_bright_yellow='#ebc13d'
+bru_espresso_bright_orange='#f19058'
+bru_espresso_bright_red='#ff665c'
+bru_espresso_bright_magenta='#ff84cd'
+bru_espresso_bright_violet='#be9af5'
+bru_espresso_bright_blue='#58a3ff'
+bru_espresso_bright_teal='#53d6c7'
+bru_espresso_bright_green='#84c747'
+
+# Latte (light) — neutrals
+bru_latte_bg='#faf3e0'
+bru_latte_bg_soft='#f3ead0'
+bru_latte_bg_hi='#ece3cc'
+bru_latte_border='#e0d4b0'
+bru_latte_fg='#3a2f22'
+bru_latte_fg_alt='#2d241a'
+bru_latte_fg_muted='#8a7f6f'
+
+# Latte accents
+bru_latte_yellow='#ad8900'
+bru_latte_orange='#c25d1e'
+bru_latte_red='#d2212d'
+bru_latte_magenta='#ca4898'
+bru_latte_violet='#8762c6'
+bru_latte_blue='#0072d4'
+bru_latte_teal='#009c8f'
+bru_latte_green='#489100'
+
+# Latte bright accents
+bru_latte_bright_yellow='#a78300'
+bru_latte_bright_orange='#bb5617'
+bru_latte_bright_red='#cc1729'
+bru_latte_bright_magenta='#c44392'
+bru_latte_bright_violet='#815cc0'
+bru_latte_bright_blue='#006dce'
+bru_latte_bright_teal='#00978a'
+bru_latte_bright_green='#428b00'

--- a/themes/loader.sh
+++ b/themes/loader.sh
@@ -39,6 +39,7 @@ get_default_variant() {
   rose-pine) echo "main" ;;
   solarized) echo "dark" ;;
   onedark) echo "dark" ;;
+  bru) echo "espresso" ;;
   *) echo "default" ;;
   esac
 }


### PR DESCRIPTION
## Summary

Adds the [bru](https://github.com/kmf/bru) colorscheme — a warm palette with solarized accents and gruvbox warmth — with two variants:

- `bru/espresso` (default dark)
- `bru/latte` (light)

Palette values verified against upstream `palette.json`. All 11 ukiyo semantic names (`text`, `bg_bar`, `bg_pane`, `highlight`, `selection`, `info`, `accent`, `notice`, `error`, `muted`, `alert`) are mapped from bru's neutrals + accents.

## Changes

- `themes/bru/palette.sh` — full bru palette, prefixed `bru_espresso_*` / `bru_latte_*` to avoid colliding with catppuccin's existing `latte_*` namespace
- `themes/bru/espresso.sh`, `themes/bru/latte.sh` — variant semantic mappings
- `themes/loader.sh` — default variant `espresso` for `bru`
- `menu_items/colors.sh` — Bru section under `prefix + T` (shortcuts `e` / `l`)
- `README.md` — usage examples

## Usage

```bash
set -g @ukiyo-theme "bru/espresso"  # default dark
set -g @ukiyo-theme "bru/latte"     # light
```

## Test plan

- [x] `load_theme bru espresso` resolves all 11 semantic names to expected hexes
- [x] `load_theme bru latte` resolves all 11 semantic names to expected hexes
- [x] `get_default_variant bru` returns `espresso`
- [x] Unknown variant errors cleanly via existing loader path
- [x] Live reload via `tmux source-file ~/.tmux.conf` applies status-bar colors correctly
- [ ] Switch between Espresso / Latte via `prefix + T` menu