### PR TITLE
feat: menu key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 Just replace all `dracula` occurrences with `ukiyo`.
 
 Select a theme using `@ukiyo-theme` with format `theme/variant`. Press prefix+T for interactive menu.
+You can change the menu keybinding or disable it using `@ukiyo-menu-key`:
+
+```bash
+set -g @ukiyo-menu-key "M"    # Change to prefix+M
+set -g @ukiyo-menu-key "none" # Disable the menu keybinding
+```
 
 ```bash
 # Kanagawa variants

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can change the menu keybinding or disable it using `@ukiyo-menu-key`:
 ```bash
 set -g @ukiyo-menu-key "M"    # Change to prefix+M
 set -g @ukiyo-menu-key "none" # Disable the menu keybinding
+set -g @ukiyo-menu-key ""     # Same as "none"
 ```
 
 ```bash

--- a/scripts/ukiyo.sh
+++ b/scripts/ukiyo.sh
@@ -12,7 +12,7 @@ migrate_legacy_options
 
 main() {
   menu_key=$(get_tmux_option "@ukiyo-menu-key" "T")
-  if [ "$menu_key" != "none" ]; then
+  if [ "$menu_key" ] && [ "$menu_key" != "none" ]; then
     tmux bind-key -r "$menu_key" run-shell "#{@ukiyo-root}/menu_items/main.sh"
   fi
 

--- a/scripts/ukiyo.sh
+++ b/scripts/ukiyo.sh
@@ -11,7 +11,10 @@ source $current_dir/theme.sh
 migrate_legacy_options
 
 main() {
-  tmux bind-key -r T run-shell "#{@ukiyo-root}/menu_items/main.sh"
+  menu_key=$(get_tmux_option "@ukiyo-menu-key" "T")
+  if [ "$menu_key" != "none" ]; then
+    tmux bind-key -r "$menu_key" run-shell "#{@ukiyo-root}/menu_items/main.sh"
+  fi
 
   # set theme
   theme_option=$(get_tmux_option "@ukiyo-theme" "")

--- a/scripts/ukiyo.sh
+++ b/scripts/ukiyo.sh
@@ -12,8 +12,17 @@ migrate_legacy_options
 
 main() {
   menu_key=$(get_tmux_option "@ukiyo-menu-key" "T")
+  bound_menu_key=$(get_tmux_option "@_ukiyo-menu-key-bound" "")
+
+  # unbind old menu key if it changed
+  if [ -n "$bound_menu_key" ] && [ "$bound_menu_key" != "$menu_key" ]; then
+    tmux unbind-key "$bound_menu_key" 2>/dev/null || true
+  fi
+
+  # bind new menu key and save state
   if [ "$menu_key" ] && [ "$menu_key" != "none" ]; then
     tmux bind-key -r "$menu_key" run-shell "#{@ukiyo-root}/menu_items/main.sh"
+    tmux set-option -gq "@_ukiyo-menu-key-bound" "$menu_key"
   fi
 
   # set theme


### PR DESCRIPTION
This pr just adds support for a new `@ukiyo-menu-key` option to customize
the key used to open the menu.
By default it's still `T`, but it can also be set to `none` or empty to disable the menu entirely.
