### PR TITLE
fix(menu): run menu scripts via shebang, not source (fixes exit 127 on dash /bin/sh)

### DIFF
--- a/menu_items/colors.sh
+++ b/menu_items/colors.sh
@@ -67,9 +67,9 @@ render_top() {
     if [[ "$current_theme" == "${prefix}"* ]]; then
       marker="*"
     fi
-    args+=("${label}${marker} >" "$key" "run -b 'UKIYO_MENU_FAMILY=${id} source #{@ukiyo-root}/menu_items/colors.sh'")
+    args+=("${label}${marker} >" "$key" "run -b 'UKIYO_MENU_FAMILY=${id} #{@ukiyo-root}/menu_items/colors.sh'")
   done
-  args+=("" "<-- Back" "b" "run -b 'source #{@ukiyo-root}/menu_items/main.sh'" "Close menu" "q" "")
+  args+=("" "<-- Back" "b" "run -b '#{@ukiyo-root}/menu_items/main.sh'" "Close menu" "q" "")
   tmux display-menu -T "#[align=centre fg=green]Themes" -x R -y P "${args[@]}"
 }
 
@@ -97,7 +97,7 @@ render_family() {
     args+=("$marked" "$i" "run -b '#{@ukiyo-root}/scripts/actions.sh set_state_and_tmux_option theme ${family}/${vid}'")
     i=$((i + 1))
   done < <(get_variants "$family")
-  args+=("" "<-- Back" "b" "run -b 'source #{@ukiyo-root}/menu_items/colors.sh'" "Close menu" "q" "")
+  args+=("" "<-- Back" "b" "run -b '#{@ukiyo-root}/menu_items/colors.sh'" "Close menu" "q" "")
   tmux display-menu -T "#[align=centre fg=green]$title" -x R -y P "${args[@]}"
 }
 

--- a/menu_items/main.sh
+++ b/menu_items/main.sh
@@ -19,9 +19,9 @@ render() {
   tmux display-menu -T "#[align=centre fg=green]Main" -x R -y P \
     "" \
     "" \
-    "Colors" 1 "run -b 'source #{@ukiyo-root}/menu_items/colors.sh" \
-    "Plugins" 2 "run -b 'source #{@ukiyo-root}/menu_items/plugins.sh" \
-    "Options" 3 "run -b 'source #{@ukiyo-root}/menu_items/options.sh" \
+    "Colors" 1 "run -b '#{@ukiyo-root}/menu_items/colors.sh" \
+    "Plugins" 2 "run -b '#{@ukiyo-root}/menu_items/plugins.sh" \
+    "Options" 3 "run -b '#{@ukiyo-root}/menu_items/options.sh" \
     "" \
     "Close menu" q ""
 }

--- a/menu_items/options.sh
+++ b/menu_items/options.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_FILE="${BASH_SOURCE[0]}"
 CURRENT_DIR="$(dirname -- "$(readlink -f -- "$0")")"
@@ -29,12 +29,12 @@ get_option_title() {
 
 render() {
   tmux display-menu -T "#[align=centre fg=green]Options" -x R -y P \
-    "$(get_option_title show-powerline)" A "run -b 'source $ROOT_DIR/scripts/actions.sh toggle_option show-powerline; source $CURRENT_FILE'" \
-    "$(get_option_title show-fahrenheit)" B "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_option show-fahrenheit; tmux display-message \"Weather will be updated after next fetch.\"; source $CURRENT_FILE'" \
-    "$(get_option_title military-time)" C "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_option military-time; source $CURRENT_FILE'" \
-    "$(get_option_title show-flags)" D "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_option show-flags; source $CURRENT_FILE'" \
+    "$(get_option_title show-powerline)" A "run -b '$ROOT_DIR/scripts/actions.sh toggle_option show-powerline; $CURRENT_FILE'" \
+    "$(get_option_title show-fahrenheit)" B "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_option show-fahrenheit; tmux display-message \"Weather will be updated after next fetch.\"; $CURRENT_FILE'" \
+    "$(get_option_title military-time)" C "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_option military-time; $CURRENT_FILE'" \
+    "$(get_option_title show-flags)" D "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_option show-flags; $CURRENT_FILE'" \
     "" \
-    "<-- Back" b "run -b 'source #{@ukiyo-root}/menu_items/main.sh'" \
+    "<-- Back" b "run -b '#{@ukiyo-root}/menu_items/main.sh'" \
     "Close menu" q ""
 }
 

--- a/menu_items/plugins.sh
+++ b/menu_items/plugins.sh
@@ -22,28 +22,28 @@ render() {
   tmux display-menu -T "#[align=centre fg=green]Plugins" -x R -y P \
     "" \
     "" \
-    "$(get_plugin_title "battery")" A "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin battery; source $CURRENT_FILE" \
-    "$(get_plugin_title "cpu-usage")" B "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin cpu-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "git")" C "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin git; source $CURRENT_FILE" \
-    "$(get_plugin_title "gpu-usage")" D "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin gpu-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "ram-usage")" E "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin ram-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "tmux-ram-usage")" F "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin tmux-ram-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "network")" G "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin network; source $CURRENT_FILE" \
-    "$(get_plugin_title "network-bandwidth")" H "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin network-bandwidth; source $CURRENT_FILE" \
-    "$(get_plugin_title "network-ping")" I "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin network-ping; source $CURRENT_FILE" \
-    "$(get_plugin_title "ssh-session")" J "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin ssh-session; source $CURRENT_FILE" \
-    "$(get_plugin_title "attached-clients")" K "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin attached-clients; source $CURRENT_FILE" \
-    "$(get_plugin_title "network-vpn")" L "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin network-vpn; source $CURRENT_FILE" \
-    "$(get_plugin_title "weather")" M "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin weather; source $CURRENT_FILE" \
-    "$(get_plugin_title "time")" N "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin time; source $CURRENT_FILE" \
-    "$(get_plugin_title "mpc")" O "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin mpc; source $CURRENT_FILE" \
-    "$(get_plugin_title "spotify-tui")" P "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin spotify-tui; source $CURRENT_FILE" \
-    "$(get_plugin_title "playerctl")" Q "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin playerctl; source $CURRENT_FILE" \
-    "$(get_plugin_title "kubernetes-context")" R "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin kubernetes-context; source $CURRENT_FILE" \
-    "$(get_plugin_title "synchronize-panes")" S "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin synchronize-panes; source $CURRENT_FILE" \
-    "$(get_plugin_title "openconnect")" T "run -b 'source #{@ukiyo-root}/scripts/actions.sh toggle_plugin openconnect; source $CURRENT_FILE" \
+    "$(get_plugin_title "battery")" A "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin battery; $CURRENT_FILE" \
+    "$(get_plugin_title "cpu-usage")" B "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin cpu-usage; $CURRENT_FILE" \
+    "$(get_plugin_title "git")" C "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin git; $CURRENT_FILE" \
+    "$(get_plugin_title "gpu-usage")" D "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin gpu-usage; $CURRENT_FILE" \
+    "$(get_plugin_title "ram-usage")" E "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin ram-usage; $CURRENT_FILE" \
+    "$(get_plugin_title "tmux-ram-usage")" F "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin tmux-ram-usage; $CURRENT_FILE" \
+    "$(get_plugin_title "network")" G "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin network; $CURRENT_FILE" \
+    "$(get_plugin_title "network-bandwidth")" H "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin network-bandwidth; $CURRENT_FILE" \
+    "$(get_plugin_title "network-ping")" I "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin network-ping; $CURRENT_FILE" \
+    "$(get_plugin_title "ssh-session")" J "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin ssh-session; $CURRENT_FILE" \
+    "$(get_plugin_title "attached-clients")" K "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin attached-clients; $CURRENT_FILE" \
+    "$(get_plugin_title "network-vpn")" L "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin network-vpn; $CURRENT_FILE" \
+    "$(get_plugin_title "weather")" M "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin weather; $CURRENT_FILE" \
+    "$(get_plugin_title "time")" N "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin time; $CURRENT_FILE" \
+    "$(get_plugin_title "mpc")" O "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin mpc; $CURRENT_FILE" \
+    "$(get_plugin_title "spotify-tui")" P "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin spotify-tui; $CURRENT_FILE" \
+    "$(get_plugin_title "playerctl")" Q "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin playerctl; $CURRENT_FILE" \
+    "$(get_plugin_title "kubernetes-context")" R "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin kubernetes-context; $CURRENT_FILE" \
+    "$(get_plugin_title "synchronize-panes")" S "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin synchronize-panes; $CURRENT_FILE" \
+    "$(get_plugin_title "openconnect")" T "run -b '#{@ukiyo-root}/scripts/actions.sh toggle_plugin openconnect; $CURRENT_FILE" \
     "" \
-    "<-- Back" b "run -b 'source #{@ukiyo-root}/menu_items/main.sh" \
+    "<-- Back" b "run -b '#{@ukiyo-root}/menu_items/main.sh" \
     "Close menu" q ""
 }
 


### PR DESCRIPTION
## Problem
Opening any status-bar menu (`prefix + T` → Colors / Plugins / Options) fails on systems where `/bin/sh` is dash (Debian, Ubuntu, and derivatives):

```
'source .../menu_items/colors.sh' returned 127
```

tmux's `run-shell` always executes via `/bin/sh`. The menus invoke their scripts with `run -b 'source <script>'`, but dash has no `source` builtin (it uses `.`), so every menu action exits 127. `.`-sourcing wouldn't help either: these scripts use bash arrays and `${BASH_SOURCE[0]}`, so they must run under bash regardless.

## Fix
Execute the menu scripts directly so the kernel honors their `#!/usr/bin/env bash` shebang, instead of sourcing them under `/bin/sh`. This matches the pattern the code already uses for `scripts/actions.sh` (see `colors.sh`), and resolves bash from `PATH` on any platform.

- Replace `source <script>` with direct execution in all `run -b` menu commands (`main.sh`, `colors.sh`, `options.sh`, `plugins.sh`). Env-var prefixes (`UKIYO_MENU_FAMILY=...`) and re-invocation via `$CURRENT_FILE` still work.
- Fix `menu_items/options.sh` shebang: it was `!/bin/bash` (missing the leading `#`), a latent bug that was harmless only while the file was sourced. Now `#!/usr/bin/env bash`, consistent with the other menu files.
- `chmod +x menu_items/options.sh` (was `0644`) so it can be executed directly.

## Testing
On Ubuntu (`/bin/sh` → dash), all four menus now open without error: `prefix + T`, then Colors → pick a theme, Plugins → toggle, Options → toggle. Verified each script runs under `sh -c '<path>'` with no `127` / `not found` / `Bad substitution`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015csduVTbi7KsNTStWKUeY1
