### PR TITLE
Fix: Prevent cpu_info script from breaking on non-English systems

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # setting the locale, some users have issues with different locales, this forces the correct one
-export LC_ALL=en_US.UTF-8
+export LC_ALL=C
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $current_dir/utils.sh
@@ -8,7 +8,7 @@ source $current_dir/utils.sh
 get_percent() {
   case $(uname -s) in
   Linux)
-    percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+    percent=$(top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
     normalize_percent_len $percent
     ;;
 


### PR DESCRIPTION
### Description
Currently, the CPU module fails to display the percentage on systems with non-English locales. The script uses grep "Cpu(s)", but depending on the system's language settings, top translates or capitalizes the output (e.g., %CPU(s) instead of %Cpu(s)). This causes grep to fail silently, rendering only the CPU name/icon without the numbers.

### Changes Made
Prefixed the top command execution with LC_ALL=C (POSIX locale).
This guarantees that top will always output the exact string %Cpu(s) and use a dot . as the decimal separator(no need to set LC_NUMERIC, LC_ALL already does this).